### PR TITLE
Custom framework patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ Nitra is a multi-process, optionally multi-server rspec and cucumber runner that
 ## Usage
       nitra [options] [spec_filename [...]]
           -c, --cpus NUMBER                Specify the number of CPUs to use on the host, or if specified after a --slave, on the slave
-              --cucumber                   Add full cucumber run, causes any files you list manually to be ignored
+              --cucumber [PATTERN1,PATTERN2]
+                                           Full cucumber run, causes any files you list manually to be ignored.
+                                           Default pattern is "features/**/*.feature".
               --debug                      Print debug output
           -p, --print-failures             Print failures immediately when they occur
           -q, --quiet                      Quiet; don't display progress bar
@@ -28,7 +30,9 @@ Nitra is a multi-process, optionally multi-server rspec and cucumber runner that
                                            Reset database, equivalent to --rake-before-worker db:reset
               --slave-mode                 Run in slave mode; ignores all other command-line options
               --slave CONNECTION_COMMAND   Provide a command that executes "nitra --slave-mode" on another host
-              --rspec                      Add full rspec run, causes any files you list manually to be ignored
+              --rspec [PATTERN1,PATTERN2]  Full rspec run, causes any files you list manually to be ignored.
+                                           Default pattern is "spec/**/*_spec.rb".
+              --slave-mode                 Run in slave mode; ignores all other command-line options
           -e, --environment ENV            Set the RAILS_ENV to load
           -h, --help                       Show this message
 

--- a/lib/nitra/command_line.rb
+++ b/lib/nitra/command_line.rb
@@ -18,7 +18,10 @@ module Nitra
           configuration.set_process_count n
         end
 
-        opts.on("--cucumber [PATTERN1, PATTERN2]", Array, "Add full cucumber run, causes any files you list manually to be ignored") do |patterns|
+        opts.on("--cucumber [PATTERN1,PATTERN2]", Array,
+                "Full cucumber run, causes any files you list manually to be ignored.",
+                "Default pattern is \"features/**/*.feature\"."
+               ) do |patterns|
           configuration.add_framework("cucumber", patterns || ["features/**/*.feature"])
         end
 
@@ -50,7 +53,10 @@ module Nitra
           configuration.add_rake_task(:before_worker, "db:reset")
         end
 
-        opts.on("--rspec [PATTERN1, PATTERN2]", Array, "Add full rspec run, causes any files you list manually to be ignored") do |patterns|
+        opts.on("--rspec [PATTERN1,PATTERN2]", Array,
+                "Full rspec run, causes any files you list manually to be ignored.",
+                "Default pattern is \"spec/**/*_spec.rb\"."
+               ) do |patterns|
           configuration.add_framework("rspec", patterns || ["spec/**/*_spec.rb"])
         end
 

--- a/lib/nitra/command_line.rb
+++ b/lib/nitra/command_line.rb
@@ -18,8 +18,8 @@ module Nitra
           configuration.set_process_count n
         end
 
-        opts.on("--cucumber", "Add full cucumber run, causes any files you list manually to be ignored") do
-          configuration.add_framework "cucumber"
+        opts.on("--cucumber [PATTERN1, PATTERN2]", Array, "Add full cucumber run, causes any files you list manually to be ignored") do |patterns|
+          configuration.add_framework("cucumber", patterns || ["features/**/*.feature"])
         end
 
         opts.on("--debug", "Print debug output") do
@@ -50,8 +50,8 @@ module Nitra
           configuration.add_rake_task(:before_worker, "db:reset")
         end
 
-        opts.on("--rspec", "Add full rspec run, causes any files you list manually to be ignored") do
-          configuration.add_framework "rspec"
+        opts.on("--rspec [PATTERN1, PATTERN2]", Array, "Add full rspec run, causes any files you list manually to be ignored") do |patterns|
+          configuration.add_framework("rspec", patterns || ["spec/**/*_spec.rb"])
         end
 
         opts.on("--slave-mode", "Run in slave mode; ignores all other command-line options") do

--- a/lib/nitra/configuration.rb
+++ b/lib/nitra/configuration.rb
@@ -9,13 +9,13 @@ module Nitra
       self.environment = "test"
       self.slaves = []
       self.rake_tasks = {}
-      self.frameworks = []
+      self.frameworks = {}
       self.max_attempts = 5
       calculate_default_process_count
     end
 
-    def add_framework(framework)
-      frameworks << framework
+    def add_framework(framework, patterns)
+      frameworks[framework] = patterns
     end
 
     def add_rake_task(name, list)

--- a/lib/nitra/master.rb
+++ b/lib/nitra/master.rb
@@ -7,7 +7,7 @@ class Nitra::Master
       load_files_from_framework_list
     else
       map_files_to_frameworks(files)
-      @configuration.frameworks = files_by_framework.keys
+      @configuration.frameworks = files_by_framework
     end
   end
 
@@ -93,8 +93,8 @@ protected
   end
 
   def load_files_from_framework_list
-    @files_by_framework = configuration.frameworks.inject({}) do |result, framework_name|
-      files = Nitra::Workers::Worker.worker_classes[framework_name].files
+    @files_by_framework = configuration.frameworks.inject({}) do |result, (framework_name, framework_patterns)|
+      files = Nitra::Workers::Worker.worker_classes[framework_name].files(framework_patterns)
       result[framework_name] = files unless files.empty?
       result
     end

--- a/lib/nitra/runner.rb
+++ b/lib/nitra/runner.rb
@@ -66,7 +66,7 @@ class Nitra::Runner
 
   def start_workers
     (1..configuration.process_count).collect do |index|
-      framework = configuration.start_framework || configuration.frameworks[index % configuration.frameworks.size]
+      framework = configuration.start_framework || configuration.frameworks.keys[index % configuration.frameworks.size]
       start_worker(index, framework)
     end if configuration.frameworks.size > 0
   end

--- a/lib/nitra/worker.rb
+++ b/lib/nitra/worker.rb
@@ -22,6 +22,10 @@ module Nitra
         def framework_name
           self.name.split("::").last.downcase
         end
+
+        def files(patterns)
+          Dir[*patterns].sort_by {|f| File.size(f)}.reverse
+        end
       end
 
       class RetryException < Exception; end

--- a/lib/nitra/workers/cucumber.rb
+++ b/lib/nitra/workers/cucumber.rb
@@ -1,9 +1,5 @@
 module Nitra::Workers
   class Cucumber < Worker
-    def self.files
-      Dir["features/**/*.feature"].sort_by {|f| File.size(f)}.reverse
-    end
-
     def self.filename_match?(filename)
       filename =~ /\.feature/
     end

--- a/lib/nitra/workers/rspec.rb
+++ b/lib/nitra/workers/rspec.rb
@@ -1,9 +1,5 @@
 module Nitra::Workers
   class Rspec < Worker
-    def self.files
-      Dir["spec/**/*_spec.rb"].sort_by {|f| File.size(f)}.reverse
-    end
-
     def self.filename_match?(filename)
       filename =~ /_spec\.rb/
     end


### PR DESCRIPTION
Implement support for custom file patterns for Cucumber and RSpec.

For example:

```
--rspec spec/**/*_spec.rb,unit/**/*_spec.rb
```

will pickup specs from both `spec/` and `unit/` dirs.
