### PR TITLE
Add basic support for Cucumber's scenario outlines

### DIFF
--- a/lib/nitra/command_line.rb
+++ b/lib/nitra/command_line.rb
@@ -98,7 +98,7 @@ module Nitra
         end
       end.parse!(argv)
 
-      puts "You should use the --rspec and/or --cucumber options to run some tests." if ARGV.empty? && configuration.frameworks.empty? && !configuration.slave_mode
+      puts "You should use the --rspec and/or --cucumber options to run some tests." if argv.empty? && configuration.frameworks.empty? && !configuration.slave_mode
     end
   end
 end

--- a/nitra.gemspec
+++ b/nitra.gemspec
@@ -1,6 +1,6 @@
 spec = Gem::Specification.new do |s|
   s.name = 'nitra'
-  s.version = '1.0.0'
+  s.version = '1.0.1'
   s.platform = Gem::Platform::RUBY
   s.license = "MIT"
   s.homepage = "http://github.com/powershop/nitra"

--- a/nitra.gemspec
+++ b/nitra.gemspec
@@ -18,6 +18,7 @@ spec = Gem::Specification.new do |s|
   s.add_dependency('cucumber', '>= 1.1.9')
   s.add_dependency('rspec')
 
+  s.add_development_dependency 'rake'
   s.add_development_dependency 'minitest'
   s.add_development_dependency 'minitest-reporters'
 

--- a/spec/nitra/command_line_spec.rb
+++ b/spec/nitra/command_line_spec.rb
@@ -149,8 +149,6 @@ describe Nitra::CommandLine do
     it "parses out options and leavs only files in list" do
       argv = ['--slave','the slave command','this_test_file_spec.rb']
       config.expect(:add_slave, nil, ['the slave command'])
-      config.expect(:frameworks, {})
-      config.expect(:slave_mode, false)
       Nitra::CommandLine.new(config, argv)
       config.verify
       argv.must_equal ['this_test_file_spec.rb']


### PR DESCRIPTION
Currently, when nitra attempts to split cucumber files and encounters a scenario outline (with corresponding examples), it attempts to derive the example location and faults.

This change treats a scenario outline as an atomic object, rather than trying to split the individual examples (which would be a nice feature).