### PR TITLE
List 100 slowest tasks in nitra burndown chart

### DIFF
--- a/lib/nitra/burndown.rb
+++ b/lib/nitra/burndown.rb
@@ -2,7 +2,7 @@ require 'ostruct'
 require 'erb'
 
 class Nitra::Burndown
-  attr_accessor :runners, :started_at, :finished_at
+  attr_accessor :runners, :started_at, :finished_at, :all_results
 
   class Result < OpenStruct
     def filename_without_path
@@ -33,6 +33,7 @@ class Nitra::Burndown
 
   def initialize
     @runners = {}
+    @all_results = []
   end
 
   def start
@@ -55,6 +56,7 @@ class Nitra::Burndown
     result[:tests] = tests
     result[:failures] = failures
     result[:failure] = failure
+    @all_results << result
     result.duration
   end
 

--- a/templates/burndown.html.erb
+++ b/templates/burndown.html.erb
@@ -1,38 +1,51 @@
 <html>
-	<head>
-		<title>Nitra burndown report</title>
-		<style type="text/css">
-			body { background-color: #eee; font: 9pt Helvetica, Arial, sans-serif; }
-			.runner { margin-top: 20px; }
-			.runner_label { line-height: 20px; font-weight: bold; }
-			.worker { height: 20px; position: relative; padding-left: 20px; background: white; }
-			.worker:nth-child(even) { background: #f7f7f7; }
-			.worker_label { float: left; position: absolute; top: 0px; margin-left: -20px; width: 20px; height: 20px; line-height: 20px; }
-			.framework, .file { float: left; position: absolute; top: 0px; height: 19px; line-height: 19px; border: 1px solid #ccc; border-top: none; white-space: nowrap; overflow: hidden; }
-			.file.success { background-color: #bbeebb; }
-			.file.failure { background-color: #ffcccc; }
-			.file.retried { background-color: #ffffcc; }
-			.framework { background-color: white; color: #007700; font-size: 7.5pt; font-weight: bold; }
-		</style>
-	</head>
-	<body>
-		Nitra run took <%= '%0.2f' % runtime %>s.
-		<% runners.sort_by {|runner_id, workers| runner_id.gsub(/\d+/) {|digits| digits.rjust(10)}}.each do |runner_id, workers| %>
-		<div class="runner">
-			<div class="runner_label"><%= runner_id %></div>
-			<% workers.each do |worker_id, results| %>
-			<div class="worker">
-				<div class="worker_label">:<%= worker_id %></div>
-				<% results.each do |result| %>
-				<% classification = result[:failure] ? 'failure' : (result[:retried] ? 'retried' : 'success') %>
-				<div class="<%= result[:filename] ? 'file' : 'framework' %> <%= result[:framework].downcase %> <%= classification %>"
-					style="left: <%= '%0.2f' % (result[:start_time]*100/runtime) %>%; width: <%= '%0.2f' % (result.duration*100/runtime) %>%;" title="<%= result.label %>">
-					<%= result.short_label %>
-				</div>
-				<% end %>
-			</div>
-			<% end %>
-		</div>
-		<% end %>
-	</body>
+  <head>
+    <title>Nitra burndown report</title>
+    <style type="text/css">
+      body { background-color: #eee; font: 9pt Helvetica, Arial, sans-serif; }
+      .runner { margin-top: 20px; }
+      .runner_label { line-height: 20px; font-weight: bold; }
+      .worker { height: 20px; position: relative; padding-left: 20px; background: white; }
+      .worker:nth-child(even) { background: #f7f7f7; }
+      .worker_label { float: left; position: absolute; top: 0px; margin-left: -20px; width: 20px; height: 20px; line-height: 20px; }
+      .framework, .file { float: left; position: absolute; top: 0px; height: 19px; line-height: 19px; border: 1px solid #ccc; border-top: none; white-space: nowrap; overflow: hidden; }
+      .file.success { background-color: #bbeebb; }
+      .file.failure { background-color: #ffcccc; }
+      .file.retried { background-color: #ffffcc; }
+      .framework { background-color: white; color: #007700; font-size: 7.5pt; font-weight: bold; }
+      td.number { text-align: right; }
+      .slowest-results { font-size: 7.5pt; }
+    </style>
+  </head>
+  <body>
+    Nitra run took <%= '%0.2f' % runtime %>s.
+    <% runners.sort_by {|runner_id, workers| runner_id.gsub(/\d+/) {|digits| digits.rjust(10)}}.each do |runner_id, workers| %>
+    <div class="runner">
+      <div class="runner_label"><%= runner_id %></div>
+      <% workers.each do |worker_id, results| %>
+      <div class="worker">
+        <div class="worker_label">:<%= worker_id %></div>
+        <% results.each do |result| %>
+        <% classification = result[:failure] ? 'failure' : (result[:retried] ? 'retried' : 'success') %>
+        <div class="<%= result[:filename] ? 'file' : 'framework' %> <%= result[:framework].downcase %> <%= classification %>"
+          style="left: <%= '%0.2f' % (result[:start_time]*100/runtime) %>%; width: <%= '%0.2f' % (result.duration*100/runtime) %>%;" title="<%= result.label %>">
+          <%= result.short_label %>
+        </div>
+        <% end %>
+      </div>
+      <% end %>
+    </div>
+    <% end %>
+    Slowest 100 tasks:
+    <table class="slowest-results">
+      <thead>
+        <tr><th>Task</th><th>Time</th></tr>
+      </thead>
+      <tbody>
+    <% all_results.sort_by { |result| -result.duration }.first(100).each do |result| %>
+        <tr><td><%= result.label %></td><td class="number"><%= '%0.2f' % result.duration %> sec</td></tr>
+    <% end %>
+      </tbody>
+    </table>
+  </body>
 </html>

--- a/templates/burndown.html.erb
+++ b/templates/burndown.html.erb
@@ -36,6 +36,7 @@
       <% end %>
     </div>
     <% end %>
+    <p>
     Slowest 100 tasks:
     <table class="slowest-results">
       <thead>


### PR DESCRIPTION
This helps us find the slowest specs without having to guess randomly from the burndown:

![screen shot 2017-06-02 at 4 36 00 pm](https://cloud.githubusercontent.com/assets/3889656/26711028/c3611fa2-47b1-11e7-8e35-dbcb9e0e56ba.png)

Also change `burndown.html.erb` indentation to use spaces, not tabs, because that's what the Ruby files in this project use too